### PR TITLE
Gcc execution errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/node": "^7.10.3",
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
-    "compile-run": "^2.3.1",
+    "compile-run": "git+https://github.com/juliocpmelo/compile-run.git",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/src/controllers/submissionController.js
+++ b/src/controllers/submissionController.js
@@ -39,11 +39,12 @@ class SubmissionController{
 				}
 				else if(linguagem==='c'){
 			    	return c.runSource(codigo,{
-				    	timeout         : timeout,
-				    	compileTimeout  : 60000,
-				    	stdin           : result.inputs || undefined,
-				    	compilationPath : URL_GCC
-				    });
+						timeout         : timeout,
+						compileTimeout  : 60000,
+						stdin           : result.inputs || undefined,
+						compilationPath : URL_GCC,
+						compilerArgs : "-lm"
+					});
 		    	}
 		    	else if(linguagem==='python'){
 			    	return python.runSource(codigo,{
@@ -99,6 +100,7 @@ class SubmissionController{
 		    	}
 		
 		    	if(erro || resp_teste.errorType){
+					console.log("error type " + erro + ", " + resp_teste.errorType );
 					algumErro = true
 			    	result.stderr = erro;
 			    	result.errorType = resp_teste.errorType;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <math.h>
+
+int main(){
+    printf("%lf\n", sqrt(8));
+    printf("%lf\n", pow(2,3));
+    *(int*)0 = 0;
+    return 25;
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -4,6 +4,8 @@
 int main(){
     printf("%lf\n", sqrt(8));
     printf("%lf\n", pow(2,3));
-    *(int*)0 = 0;
-    return 25;
+    while(1){
+        printf("é nois!\n");
+    }
+    return -1;
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,22 @@
+const {c, cpp, node, python, java} = require('compile-run');
+const {URL_GPP, URL_GCC, URL_PYTHON} = require('../src/env')
+
+let p = c.runFile("./tests/test.c",
+                    {
+                        timeout : 3000,
+                        compileTimeout  : 60000,
+                        stdin : undefined,
+                        compilationPath : URL_GCC,
+                        compilerArgs : "-lm"
+                    });
+
+p
+    .then(result => {
+        console.log("result");
+        console.log(result);//result object
+    })
+    .catch(err => {
+        console.log("Error!");
+        console.log(err);
+    });
+


### PR DESCRIPTION
Corrigindo alguns problemas de execução de programas em c
Tambem adicionei uma forma local de testar o api-run-code.
Fiz algumas modificações no compile-run por isso temos que mudar a dependencia no package.json para a versão que está disponível no meu repositório.